### PR TITLE
Add simplified logic for interim context propagation

### DIFF
--- a/exporter/exporterhelper/internal/queuebatch/batch_context.go
+++ b/exporter/exporterhelper/internal/queuebatch/batch_context.go
@@ -5,13 +5,23 @@ package queuebatch // import "go.opentelemetry.io/collector/exporter/exporterhel
 
 import (
 	"context"
+	"slices"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/otel/trace"
 )
 
 type traceContextKeyType int
 
 const batchSpanLinksKey traceContextKeyType = iota
+
+// allowedContextKeys is a hardcoded list of context keys that are added
+// to the context propogated by the batcher. This is an interim solution
+// until https://github.com/open-telemetry/opentelemetry-collector/issues/13320
+// is resolved and is kept simple for better maintainability across updates.
+var allowedContextKeys = []string{
+	"x-elastic-project-id",
+}
 
 // LinksFromContext returns a list of trace links registered in the context.
 func LinksFromContext(ctx context.Context) []trace.Link {
@@ -32,8 +42,22 @@ func parentsFromContext(ctx context.Context) []trace.Link {
 }
 
 func contextWithMergedLinks(ctx1 context.Context, ctx2 context.Context) context.Context {
+	meta1 := client.FromContext(ctx1).Metadata
+	meta2 := client.FromContext(ctx2).Metadata
+	m := make(map[string][]string)
+	for _, ak := range allowedContextKeys {
+		v1 := meta1.Get(ak)
+		v2 := meta2.Get(ak)
+		if len(v1) == 0 && len(v2) == 0 {
+			continue
+		}
+		if !slices.Equal(v1, v2) {
+			panic("unexpected metadata keys, the partition has allowed metadata keys with different values")
+		}
+		m[ak] = slices.Clone(v1)
+	}
 	return context.WithValue(
-		context.Background(),
+		client.NewContext(context.Background(), client.Info{Metadata: client.NewMetadata(m)}),
 		batchSpanLinksKey,
 		append(parentsFromContext(ctx1), parentsFromContext(ctx2)...),
 	)

--- a/exporter/exporterhelper/internal/queuebatch/batch_context_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/batch_context_test.go
@@ -45,6 +45,7 @@ func TestBatchContextLinkMetadataPropogation(t *testing.T) {
 		name                 string
 		metadata1, metadata2 map[string][]string
 		panicMsg             string
+		expectedMetadata     map[string][]string
 	}{
 		{
 			name: "no_allowed_keys",
@@ -77,8 +78,15 @@ func TestBatchContextLinkMetadataPropogation(t *testing.T) {
 			name: "metadata_correct",
 			metadata1: map[string][]string{
 				"x-elastic-project-id": []string{"pid1"},
+				"other-metadata-1":     []string{"other1"},
+				"other-metadata-2":     []string{"other2"},
 			},
 			metadata2: map[string][]string{
+				"x-elastic-project-id": []string{"pid1"},
+				"other-metadata-1":     []string{"other1"},
+				"other-metadata-3":     []string{"other3"},
+			},
+			expectedMetadata: map[string][]string{
 				"x-elastic-project-id": []string{"pid1"},
 			},
 		},
@@ -94,9 +102,14 @@ func TestBatchContextLinkMetadataPropogation(t *testing.T) {
 			)
 
 			if tc.panicMsg == "" {
-				assert.NotPanics(t, func() { contextWithMergedLinks(ctx1, ctx2) })
+				require.NotPanics(t, func() { contextWithMergedLinks(ctx1, ctx2) })
+				ctx := contextWithMergedLinks(ctx1, ctx2)
+				actualMetadata := client.FromContext(ctx).Metadata
+				for k := range actualMetadata.Keys() {
+					assert.Equal(t, tc.expectedMetadata[k], actualMetadata.Get(k))
+				}
 			} else {
-				assert.PanicsWithValue(t, tc.panicMsg, func() { contextWithMergedLinks(ctx1, ctx2) })
+				require.PanicsWithValue(t, tc.panicMsg, func() { contextWithMergedLinks(ctx1, ctx2) })
 			}
 		})
 	}

--- a/exporter/exporterhelper/internal/queuebatch/batch_context_test.go
+++ b/exporter/exporterhelper/internal/queuebatch/batch_context_test.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
 
+	"go.opentelemetry.io/collector/client"
 	"go.opentelemetry.io/collector/component/componenttest"
 )
 
@@ -36,4 +38,66 @@ func TestBatchContextLink(t *testing.T) {
 	require.Equal(t, trace.SpanContextFromContext(ctx2), actualLinks[0].SpanContext)
 	require.Equal(t, trace.SpanContextFromContext(ctx3), actualLinks[1].SpanContext)
 	require.Equal(t, trace.SpanContextFromContext(ctx4), actualLinks[2].SpanContext)
+}
+
+func TestBatchContextLinkMetadataPropogation(t *testing.T) {
+	for _, tc := range []struct {
+		name                 string
+		metadata1, metadata2 map[string][]string
+		panicMsg             string
+	}{
+		{
+			name: "no_allowed_keys",
+		},
+		{
+			name: "metadata1_allowed_keys",
+			metadata1: map[string][]string{
+				"x-elastic-project-id": []string{"pid1"},
+			},
+			panicMsg: "unexpected metadata keys, the partition has allowed metadata keys with different values",
+		},
+		{
+			name: "metadata2_allowed_keys",
+			metadata2: map[string][]string{
+				"x-elastic-project-id": []string{"pid2"},
+			},
+			panicMsg: "unexpected metadata keys, the partition has allowed metadata keys with different values",
+		},
+		{
+			name: "metadata_unequal",
+			metadata1: map[string][]string{
+				"x-elastic-project-id": []string{"pid1"},
+			},
+			metadata2: map[string][]string{
+				"x-elastic-project-id": []string{"pid2"},
+			},
+			panicMsg: "unexpected metadata keys, the partition has allowed metadata keys with different values",
+		},
+		{
+			name: "metadata_correct",
+			metadata1: map[string][]string{
+				"x-elastic-project-id": []string{"pid1"},
+			},
+			metadata2: map[string][]string{
+				"x-elastic-project-id": []string{"pid1"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx1 := client.NewContext(
+				context.Background(),
+				client.Info{Metadata: client.NewMetadata(tc.metadata1)},
+			)
+			ctx2 := client.NewContext(
+				context.Background(),
+				client.Info{Metadata: client.NewMetadata(tc.metadata2)},
+			)
+
+			if tc.panicMsg == "" {
+				assert.NotPanics(t, func() { contextWithMergedLinks(ctx1, ctx2) })
+			} else {
+				assert.PanicsWithValue(t, tc.panicMsg, func() { contextWithMergedLinks(ctx1, ctx2) })
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->
#### Description

Adds a simplified logic for context propagation with hard-coded keys. The simplified logic should allow for better maintainability. The logic also doesn't adopt the currently proposed solution for handling context propagation to keep the need for forking upstream as minimal as possible.

<!--Describe what testing was performed and which tests were added.-->
#### Testing

Unit tests added.

<!--Describe the documentation added.-->
#### Documentation

NA